### PR TITLE
Cache topics to avoid querying for them

### DIFF
--- a/lib/queue-pubsub.js
+++ b/lib/queue-pubsub.js
@@ -12,6 +12,7 @@ class QueuePubSub {
    */
   constructor(options) {
     this.setOptions(options);
+    this.topics = {};
   }
 
   /**
@@ -162,10 +163,17 @@ class QueuePubSub {
    * @returns {Promise<Topic>}
    */
   createTopic(topicName) {
+    const existing = this.topics[topicName];
+    if (existing) {
+      return Promise.resolve(existing);
+    }
     return this.pubsub
       .topic(topicName)
       .get({ autoCreate: this.options.autoCreate })
-      .then(([topic]) => topic);
+      .then(([topic]) => {
+        this.topics[topicName] = topic;
+        return topic;
+      });
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exchange-pubsub",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "A wrapper to simplify basic pubsub usage",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
reduces admin requests (Get) on every publish event